### PR TITLE
Correction for use with atoum >= 2.1

### DIFF
--- a/classes/asserters/json.php
+++ b/classes/asserters/json.php
@@ -9,7 +9,16 @@ use mageekguy\atoum\asserters;
 use mageekguy\atoum\exceptions;
 use mageekguy\atoum\jsonSchema\retriever;
 
-class json extends asserters\string
+if (class_exists('mageekguy\atoum\asserters\phpString'))
+{
+	class stringAsserter extends asserters\phpString {}
+}
+else
+{
+	class stringAsserter extends asserters\string {}
+}
+
+class json extends stringAsserter
 {
 	protected $innerAsserter;
 	protected $data;
@@ -125,4 +134,4 @@ class json extends asserters\string
 			($decoded !== null || strtolower(trim($value)) === 'null')
 		);
 	}
-} 
+}

--- a/tests/units/classes/asserters/json.php
+++ b/tests/units/classes/asserters/json.php
@@ -11,9 +11,11 @@ class json extends atoum\test
 {
 	public function testClass()
 	{
+		$namespace = 'mageekguy\\atoum\\asserters';
+		$className = class_exists($namespace . '\\phpString') ? 'phpString' : 'string';
 		$this
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\asserters\string')
+				->isSubClassOf($namespace . '\\' . $className)
 		;
 	}
 


### PR DESCRIPTION
On atoum 2.1, string asserter was renamed to phpString for use with php 7.
This PR made correction to use phpString asserter when exists else continue to use string asserter.